### PR TITLE
No module named 'pyperclip'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     packages=['xontrib'],
     package_dir={'xontrib': 'xontrib'},
     package_data={'xontrib': ['*.xsh']},
+    install_requires=['pyperclip'],
     platforms='any',
     classifiers=[
         'Environment :: Console',


### PR DESCRIPTION
Fix
```
$ xontrib load histcpy                                                                                            
xonsh: For full traceback set: $XONSH_SHOW_TRACEBACK = True
ModuleNotFoundError: No module named 'pyperclip'
```